### PR TITLE
exclude .gitignore and friends from archive files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+/.*		export-ignore


### PR DESCRIPTION
when downloading a tagged release from github, the file includes repository housekeeping files like `.gitexclude`, which is often unwanted, as these files only make sense when used from the repository.

this PR excludes dotfiles (`.git*`, but also`.directory`) from the final archive.