### PR TITLE
Makefile.pdlibbuilder: ia64 is not x86

### DIFF
--- a/Makefile.pdlibbuilder
+++ b/Makefile.pdlibbuilder
@@ -421,7 +421,7 @@ ifeq ($(findstring $(machine), i386 i686), $(machine))
 endif
 
 # Intel/AMD 64 bit, build with SSE, SSE2 and SSE3 instructions
-ifeq ($(findstring $(machine), ia64 x86_64), $(machine))
+ifeq ($(findstring $(machine), x86_64), $(machine))
   arch.flags = -march=core2 -mfpmath=sse -msse -msse2 -msse3 
 endif
 


### PR DESCRIPTION
Itanium (ia64) is a completely separate architecture to x86 that happens to also be from Intel, so should not be using x86-specific compiler flags.