### PR TITLE
Use standard PDLIBBUILDER_DIR variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,8 @@ datadirs = img
 
 cflags = -Wno-unused -Wno-unused-parameter
 
-PDLIBBUILDERDIR ?= .
-include $(PDLIBBUILDERDIR)/Makefile.pdlibbuilder
+PDLIBBUILDER_DIR ?= .
+include $(PDLIBBUILDER_DIR)/Makefile.pdlibbuilder
 
 VERSION = $(shell git describe --abbrev=4)
 


### PR DESCRIPTION
Use the standard `PDLIBBUILDER_DIR` makefile-variable for locating pd-lib-builder rather than `PDLIBBUILDERDIR`.

The standardized variable name (as documented in https://github.com/pure-data/pd-lib-builder/blob/master/tips-tricks.md#project-management) simplifies packaging (as it allows us to use the same build-system invocation for virtually all pd-lib-builder based projects)
