### PR TITLE
various fixes from the Debian packaging

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,6 @@
 MOONLIB puredata externals
 
-- tabenv : like env~, an enveloppe follower, but computing on a table, so
+- tabenv : like env~, an envelope follower, but computing on a table, so
     possibly faster than real-time env~'s computation.
 
 - tabsort and tabsort2 : return the indices of the sorted table (tabsort2
@@ -9,7 +9,7 @@ MOONLIB puredata externals
 - gamme : one octave of a piano keyboard used to filter/choose notes in a
     selected scale.
 
-- absolutepath/relativepath (OBSOLETE): use datas (sounds, texts, presets, images,
+- absolutepath/relativepath (OBSOLETE): use data (sounds, texts, presets, images,
     programs...) nested in the patch's directory (and in subdirs).
 
 - sarray and slist : create shared dynamic arrays or lists with symbols.
@@ -25,7 +25,7 @@ MOONLIB puredata externals
     one pair of buses named (slider-snd/slider-rcv) , in which values are
     prepended by the number of the "sub-bus".
 
-- image : an improvment of Guenter Geiger's one. Same name, but it's
+- image : an improvement of Guenter Geiger's one. Same name, but it's
 	 compatible. Here you can share images through different objects, preload
 	 a list of images, and animate this list.
 

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ MOONLIB puredata externals
     possibly faster than real-time env~'s computation.
 
 - tabsort and tabsort2 : return the indices of the sorted table (tabsort2
-    is bidimentionnal).
+    is bidimensional).
 
 - gamme : one octave of a piano keyboard used to filter/choose notes in a
     selected scale.

--- a/f2s.c
+++ b/f2s.c
@@ -32,7 +32,7 @@ typedef struct _f2s
 {
    t_object x_ob;
 	t_float x_f;
-	int x_type; /*0: p/n/µ/m/./k/M/G with n digits */
+	int x_type; /*0: p/n/Âµ/m/./k/M/G with n digits */
 	int x_n;
 } t_f2s;
 

--- a/mknob-help.pd
+++ b/mknob-help.pd
@@ -34,7 +34,7 @@
 #X text 529 113 low sensitivity;
 #X text 442 84 Set it with the 2nd argument of "size" message:;
 #X text 6 274 (c) moonix: Antoine Rousseau 2003-2026;
-#X text 439 68 "heigth" parameter sets mouse excursion for full range.;
+#X text 439 68 "height" parameter sets mouse excursion for full range.;
 #X text 94 11 round knob GUI;
 #X text 18 50 Right-click properties to modify geometry \, colors \, etc., f 57;
 #X text 8 198 Shift-click & drag for fine-tuning (0.01 pixels), f 25;

--- a/panvol~.c
+++ b/panvol~.c
@@ -36,11 +36,11 @@ static t_class *pan_class;
 typedef struct _pan
 {
     t_object x_obj;
-    float x_f;
-    float pan;
-    float left;
-    float right;
-    float vol;
+    t_float x_f;
+    t_float pan;
+    t_float left;
+    t_float right;
+    t_float vol;
 } t_pan;
 
 static void *pan_new(t_symbol *s, int argc, t_atom *argv)
@@ -60,14 +60,14 @@ static void *pan_new(t_symbol *s, int argc, t_atom *argv)
 
 static t_int *pan_perform(t_int *w)
 {
-    float *in1 = (t_float *)(w[1]);
-    float *out1 = (t_float *)(w[2]);
-    float *out2 = (t_float *)(w[3]);
+    t_sample *in1 = (t_sample *)(w[1]);
+    t_sample *out1 = (t_sample *)(w[2]);
+    t_sample *out2 = (t_sample *)(w[3]);
     int n = (int)(w[4]);
     t_pan *x = (t_pan *)(w[5]);
-    float left=x->left*x->vol;
-    float right=x->right*x->vol;
-    float value;
+    t_float left=x->left*x->vol;
+    t_float right=x->right*x->vol;
+    t_sample value;
 
     while  (n--)
     {
@@ -81,9 +81,9 @@ static t_int *pan_perform(t_int *w)
 static void pan_dsp(t_pan *x, t_signal **sp)
 {
     int n = sp[0]->s_n;
-    float *in1 = sp[0]->s_vec;
-    float *out1 = sp[1]->s_vec;
-    float *out2 = sp[2]->s_vec;
+    t_sample *in1 = sp[0]->s_vec;
+    t_sample *out1 = sp[1]->s_vec;
+    t_sample *out2 = sp[2]->s_vec;
 
     dsp_add(pan_perform, 5,
             in1, out1, out2, n, x);

--- a/popen-help.pd
+++ b/popen-help.pd
@@ -52,17 +52,17 @@
 #X restore 19 161 pd example;
 #X obj 31 109 popen;
 #X text 20 191 Remarks:;
-#X text 46 204 The danger here comes from the fact processes lauched
+#X text 46 204 The danger here comes from the fact processes launched
 by;
 #X text 47 215 popen runs concurrently with pd: if they are blocking
 \, pd;
 #X text 46 228 is blocking too. Very dangerous if pd has real-time
-priority: it blocks all the sytem. You have to switch off the computer...
+priority: it blocks all the system. You have to switch off the computer...
 ;
-#X text 47 267 It's much safer to use netsend/netreceive in conjonction
+#X text 47 267 It's much safer to use netsend/netreceive in conjunction
 with pdsend/pdreceive.;
 #X obj 206 333 system;
-#X text 46 297 You can use "at now" to lauch programs totally independantly
+#X text 46 297 You can use "at now" to launch programs totally independently
 from Pd:;
 #X msg 206 313 echo xclock -display 0:0 | at now;
 #N canvas 370 189 494 344 META 0;

--- a/readsfv~.c
+++ b/readsfv~.c
@@ -24,10 +24,10 @@ for Windows if someone were willing to find a Pthreads package for it. */
 
 #include "_soundfile.c"
 
-static void interpolate(int nvec,float **invec,int nin,
-                        float **outvec,int nout)
+static void interpolate(int nvec,t_sample **invec,int nin,
+                        t_sample **outvec,int nout)
 {
-    float r=nin/(float)nout;
+    t_sample r=nin/(t_sample)nout;
     int i,j;
 
     for(i=0; i<nout; i++)
@@ -107,10 +107,10 @@ typedef struct _readsf
     int x_filetype; 	    /* writesf~ only; type of file to create */
     int x_itemswritten;     /* writesf~ only; items writen */
     int x_swap; 	    /* writesf~ only; true if byte swapping */
-    float x_f; 	    	    /* writesf~ only; scalar for signal inlet */
+    t_float x_f; 	    	    /* writesf~ only; scalar for signal inlet */
     /*----HACK------*/
-    float x_speed;    /*speed of reading*/
-    float x_frac;    /*fractionnal part of sample to play next buffer*/
+    t_float x_speed;    /*speed of reading*/
+    t_float x_frac;    /*fractionnal part of sample to play next buffer*/
 
     pthread_mutex_t x_mutex;
     pthread_cond_t x_requestcondition;
@@ -460,7 +460,7 @@ static t_int *readsf_perform(t_int *w)
     int vecsize = x->x_vecsize, noutlets = x->x_noutlets, i, j,
         bytespersample = x->x_bytespersample,
         bigendian = x->x_bigendian,wantsamples;
-    float *fp,tmp,speed=x->x_speed;
+    t_sample *fp,tmp,speed=x->x_speed;
     if (x->x_state == STATE_STREAM)
     {
         int wantbytes, nchannels, sfchannels = x->x_sfchannels;

--- a/sfread2~-help.pd
+++ b/sfread2~-help.pd
@@ -17,7 +17,7 @@
 #X obj 588 181 vsl 15 128 -8 8 0 0 empty empty speed 0 -8 1 8 -260818
 -1 -1 6644 1;
 #X text 135 12 soundfile reader at variable speed (possibly negative)
-\, whith 4-point interpolation and loop.;
+\, with 4-point interpolation and loop.;
 #X obj 154 296 dac~;
 #X obj 155 92 openpanel;
 #X obj 155 72 bng 15 250 50 0 empty empty open 0 -6 1 8 -166441 -1
@@ -43,7 +43,7 @@ opened (use of C function mmap()).;
 added by Jonathan Wilkes for Pd version 0.42.;
 #X text 12 5 KEYWORDS signal soundfile;
 #X text 12 45 DESCRIPTION soundfile reader at variable speed (possibly
-negative) \, whith 4-point interpolation and loop;
+negative) \, with 4-point interpolation and loop;
 #X text 12 85 INLET_0 float bang interp open index loop;
 #X text 12 105 INLET_1 float;
 #X text 12 145 comment;

--- a/sfread2~.c
+++ b/sfread2~.c
@@ -68,10 +68,10 @@ static t_int *sfread_perform(t_int *w)
     int fc = x->x_fchannels,fc2=2*fc;
     double findex = x->x_index;
     t_float speed = x->x_speed;
-    float frac,  a,  b,  cc,  d, cminusb;
+    t_sample frac,  a,  b,  cc,  d, cminusb;
     int i,n,index,rindex;
     int end =  x->x_len -3;/* -3 is for safe interpolation*/
-    t_float *out[MAX_CHANS];
+    t_sample *out[MAX_CHANS];
     t_int in_off[MAX_CHANS];
     t_int loground=(fc==1?0:fc==2?1:2);
 

--- a/ssaw~.c
+++ b/ssaw~.c
@@ -67,7 +67,7 @@ union tabfudge
 
 /* -------------------------- ssaw~ ------------------------------ */
 static t_class *ssaw_class, *scalarssaw_class;
-static float ssaw_array[1002];
+static t_sample ssaw_array[1002];
 #define SAW_ARRAY_LEN 1002
 
 typedef struct _ssaw
@@ -75,9 +75,9 @@ typedef struct _ssaw
     t_object x_obj;
     //from phasor~:
     double x_phase;
-    float x_conv;
-    float x_f;	    /* scalar frequency */
-    float x_band;	/* band limit (Hertz)*/
+    t_float x_conv;
+    t_float x_f;	    /* scalar frequency */
+    t_float x_band;	/* band limit (Hertz)*/
 } t_ssaw;
 
 static void *ssaw_new(t_floatarg f)
@@ -101,9 +101,9 @@ static t_int *ssaw_perform(t_int *w)
     double dphase = x->x_phase + UNITBIT32;
     union tabfudge tf;
     int normhipart;
-    float conv = x->x_conv;
-    float band=x->x_band*.33;
-    float *buf = ssaw_array;
+    t_sample conv = x->x_conv;
+    t_sample band=x->x_band*.33;
+    t_sample *buf = ssaw_array;
 
     tf.tf_d = UNITBIT32;
     normhipart = tf.tf_i[HIOFFSET];
@@ -112,9 +112,9 @@ static t_int *ssaw_perform(t_int *w)
     for (i = 0; i < n; i++)
         //while (n--)
     {
-        float phase,band2,findex /*= *in++*/;
+        t_sample phase,band2,findex /*= *in++*/;
         int index /*= findex*/;
-        float frac,  a,  b,  c,  d, cminusb, *fp;
+        t_sample frac,  a,  b,  c,  d, cminusb, *fp;
 
         tf.tf_i[HIOFFSET] = normhipart;
         band2=abs(*in);
@@ -170,7 +170,7 @@ static void ssaw_ft1(t_ssaw *x, t_float f)
 static void ssaw_initarray(void)
 {
     int i;
-    float j;
+    t_sample j;
 
     for(i=0; i<1002; i++)
     {

--- a/tabenv.c
+++ b/tabenv.c
@@ -32,13 +32,13 @@ typedef struct tabenv
     /*env part*/
     t_object x_obj; 	    	    /* header */
     t_outlet *x_outlet;		    /* a "float" outlet */
-    float *x_buf;		    /* a Hanning window */
+    t_sample *x_buf;		    /* a Hanning window */
     int x_phase;		    /* number of points since last output */
     int x_period;		    /* requested period of output */
     int x_realperiod;		    /* period rounded up to vecsize multiple */
     int x_npoints;		    /* analysis window size in samples */
-    float x_result;		    /* result to output */
-    float x_sumbuf[MAXOVERLAP];	    /* summing buffer */
+    t_sample x_result;		    /* result to output */
+    t_sample x_sumbuf[MAXOVERLAP];	    /* summing buffer */
 
     /*tabplay part*/
     int x_tabphase;
@@ -55,14 +55,14 @@ static void *tabenv_new(t_symbol *s,t_floatarg fnpoints, t_floatarg fperiod)
     int npoints = fnpoints;
     int period = fperiod;
     t_tabenv *x;
-    float *buf;
+    t_sample *buf;
     int i;
 
     if (npoints < 1) npoints = 1024;
     if (period < 1) period = npoints/2;
     if (period < npoints / MAXOVERLAP + 1)
         period = npoints / MAXOVERLAP + 1;
-    if (!(buf = getbytes(sizeof(float) * (npoints + MAXVSTAKEN))))
+    if (!(buf = getbytes(sizeof(t_sample) * (npoints + MAXVSTAKEN))))
     {
         pd_error(0,"env: couldn't allocate buffer");
         return (0);
@@ -90,14 +90,14 @@ static void tabenv_perform_64(t_tabenv *x,t_word *in)
 {
     int n = 64;
     int count;
-    float *sump;
+    t_sample *sump;
     in += n;
     for (count = x->x_phase, sump = x->x_sumbuf;
             count < x->x_npoints; count += x->x_realperiod, sump++)
     {
-        float *hp = x->x_buf + count;
+        t_sample *hp = x->x_buf + count;
         t_word *fp = in;
-        float sum = *sump;
+        t_sample sum = *sump;
         int i;
 
         for (i = 0; i < n; i++)
@@ -177,7 +177,7 @@ static void tabenv_reset(t_tabenv *x)
 
 static void tabenv_ff(t_tabenv *x)		/* cleanup on free */
 {
-    freebytes(x->x_buf, (x->x_npoints + MAXVSTAKEN) * sizeof(float));
+    freebytes(x->x_buf, (x->x_npoints + MAXVSTAKEN) * sizeof(t_sample));
 }
 
 

--- a/tabreadl.c
+++ b/tabreadl.c
@@ -43,7 +43,7 @@ static void tabreadl_float(t_tabreadl *x, t_float f)
     else
     {
         int n ;
-        float r,v;
+        t_float r,v;
 
         if (f < 0) f = 0;
         else if (f >= npoints) f = npoints - 1;


### PR DESCRIPTION
here's some fixes from the Debian packaging of moonlib
- spelling mistakes
- use `t_float` (and `t_sample`) instead of `float` to make moonlib ready for Pd64


there's also some more fixes that are not part of the Debian packaging (yet):
- more spelling mistakes
- use UTF-8 as the encoding for non-ASCII characters like µ